### PR TITLE
update sorting key for TableBuilder to make sure score isn't None before sorting

### DIFF
--- a/tables/builders.py
+++ b/tables/builders.py
@@ -27,7 +27,11 @@ class RottenTomatoesTableBuilder:
 
     @staticmethod
     def sort_by_score_descending(objects):
-        return sorted(objects, key=lambda obj: obj.rotten_tomatoes_score, reverse=True)
+        return sorted(
+                objects,
+                key=lambda obj: obj.rotten_tomatoes_score if obj.rotten_tomatoes_score is not None else -1,
+                reverse=True
+        )
 
     @staticmethod
     def column_format():


### PR DESCRIPTION
Hi, running this on Python3.7.4, while using these commands...

`rotten tv new`
`rotten search "harry potter"`

... I was getting errors like:

```python
❯ rotten search "harry potter"
Traceback (most recent call last):
  File "/usr/local/bin/rotten", line 11, in <module>
    load_entry_point('rotten-tomatoes-cli==0.0.1', 'console_scripts', 'rotten')()
  File "/Users/sean/Library/Python/3.7/lib/python/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/sean/Library/Python/3.7/lib/python/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/sean/Library/Python/3.7/lib/python/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/sean/Library/Python/3.7/lib/python/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/sean/Library/Python/3.7/lib/python/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/rotten_tomatoes_cli-0.0.1-py3.7.egg/scripts/search.py", line 18, in search
  File "/usr/local/lib/python3.7/site-packages/rotten_tomatoes_cli-0.0.1-py3.7.egg/tables/builders.py", line 11, in build
  File "/usr/local/lib/python3.7/site-packages/rotten_tomatoes_cli-0.0.1-py3.7.egg/tables/builders.py", line 17, in all_table_rows
  File "/usr/local/lib/python3.7/site-packages/rotten_tomatoes_cli-0.0.1-py3.7.egg/tables/builders.py", line 25, in rows
  File "/usr/local/lib/python3.7/site-packages/rotten_tomatoes_cli-0.0.1-py3.7.egg/tables/builders.py", line 33, in sort_by_score_descending
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

The corresponding name/scores:

```
[88, 90, 83, 81, None, 78, 83, 77, 96, None]
['Harry Potter and the Goblet of Fire', 'Harry Potter and the Prisoner of Azkaban', 'Harry Potter and the Chamber of Secrets', "Harry Potter and the Sorcerer's Stone", 'Discovering the Real World of Harry Potter', 'Harry Potter and the Order of the Phoenix', 'Harry Potter and the Half-Blood Prince', 'Harry Potter and the Deathly Hallows - Part 1', 'Harry Potter and the Deathly Hallows - Part 2', 'JK Rowling and the Birth of Harry Potter']
```

This happens whenever the input to the [`RottenTomatoesTableBuilder`](https://github.com/jaebradley/rotten_tomatoes_cli/blob/712e1c7b85116f274e167eee0008aee384bfaea6/tables/builders.py#L6) has more than 1 `object` and one of the `object`'s `rotten_tomatoes_score` is None.

I updated the lambda to:

`key=lambda obj: obj.rotten_tomatoes_score if obj.rotten_tomatoes_score is not None else -1`

and it now works as expected:

```

❯ rotten search "Harry Potter"
┌────────────────────────────────┬───────┬──────┬──────────────────┐
│ Film                           │ Score │ Year │ Cast             │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Deathly   │ 96%   │ 2011 │ Daniel Radcliffe │
│ Hallows - Part 2               │       │      │ Rupert Grint     │
│                                │       │      │ Emma Watson      │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Prisoner  │ 90%   │ 2004 │ Daniel Radcliffe │
│ of Azkaban                     │       │      │ Emma Watson      │
│                                │       │      │ Rupert Grint     │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Goblet of │ 88%   │ 2005 │ Daniel Radcliffe │
│ Fire                           │       │      │ Rupert Grint     │
│                                │       │      │ Emma Watson      │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Chamber   │ 83%   │ 2002 │ Daniel Radcliffe │
│ of Secrets                     │       │      │ Emma Watson      │
│                                │       │      │ Rupert Grint     │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Half-     │ 83%   │ 2009 │ Daniel Radcliffe │
│ Blood Prince                   │       │      │ Emma Watson      │
│                                │       │      │ Rupert Grint     │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the           │ 81%   │ 2001 │ Daniel Radcliffe │
│ Sorcerer's Stone               │       │      │ Emma Watson      │
│                                │       │      │ Rupert Grint     │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Order of  │ 78%   │ 2007 │ Daniel Radcliffe │
│ the Phoenix                    │       │      │ Rupert Grint     │
│                                │       │      │ Emma Watson      │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Harry Potter and the Deathly   │ 77%   │ 2010 │ Daniel Radcliffe │
│ Hallows - Part 1               │       │      │ Emma Watson      │
│                                │       │      │ Rupert Grint     │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ Discovering the Real World of  │ N/A   │ 2001 │ Hugh Laurie      │
│ Harry Potter                   │       │      │                  │
├────────────────────────────────┼───────┼──────┼──────────────────┤
│ JK Rowling and the Birth of    │ N/A   │ 2004 │ J.K. Rowling     │
│ Harry Potter                   │       │      │                  │
└────────────────────────────────┴───────┴──────┴──────────────────┘

```

Let me know if I can change anything.